### PR TITLE
refact - AuthCode Entity verifedAt -> validatedAt 으로 리네이밍

### DIFF
--- a/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/model/AuthCode.kt
+++ b/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/model/AuthCode.kt
@@ -26,5 +26,5 @@ class AuthCode(
     @Column(nullable = false)
     var requestedAt: LocalDateTime
 ) : BaseEntity() {
-    var verifiedAt: LocalDateTime? = null
+    var validatedAt: LocalDateTime? = null
 }

--- a/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/service/AuthCodeDomainService.kt
+++ b/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/service/AuthCodeDomainService.kt
@@ -30,16 +30,16 @@ class AuthCodeDomainService(
         }
 
         if (now.toLocalDate().isEqual(authCode.requestedAt.toLocalDate())) {
-            if (authCode.sendCount >= issueLimitPerDay && authCode.verifiedAt === null) {
+            if (authCode.sendCount >= issueLimitPerDay && authCode.validatedAt === null) {
                 throw TooManyAuthCodeRequestException("일일 요청 제한을 초과하였습니다")
             }
-            authCode.sendCount = if (authCode.verifiedAt === null) authCode.sendCount + 1 else 1
+            authCode.sendCount = if (authCode.validatedAt === null) authCode.sendCount + 1 else 1
         } else {
             authCode.sendCount = 1
         }
 
         authCode.requestedAt = LocalDateTime.now()
-        authCode.verifiedAt = null
+        authCode.validatedAt = null
 
         return authCodeRepository.save(authCode)
     }
@@ -52,11 +52,11 @@ class AuthCodeDomainService(
             throw InvalidAuthCodeException("유효하지 않은 인증 코드입니다")
         }
 
-        if (authCode.code !== code || authCode.verifiedAt !== null) {
+        if (authCode.code !== code || authCode.validatedAt !== null) {
             throw InvalidAuthCodeException("유효하지 않은 인증 코드입니다")
         }
 
-        authCode.verifiedAt = LocalDateTime.now()
+        authCode.validatedAt = LocalDateTime.now()
         authCodeRepository.save(authCode)
 
         return true

--- a/src/main/resources/db/migration/V3__rename_verified_at_to_validated_at_on_auth_code_table.sql
+++ b/src/main/resources/db/migration/V3__rename_verified_at_to_validated_at_on_auth_code_table.sql
@@ -1,0 +1,1 @@
+alter table auth_code rename column verified_at to validated_at;

--- a/src/test/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/service/AuthCodeDomainServiceTest.kt
+++ b/src/test/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/service/AuthCodeDomainServiceTest.kt
@@ -62,7 +62,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
         Assertions.assertSame(expectedAuthCode.code, result.code)
         Assertions.assertSame(expectedAuthCode.sendCount, result.sendCount)
         Assertions.assertTrue(now.isEqual(result.requestedAt))
-        Assertions.assertNull(result.verifiedAt)
+        Assertions.assertNull(result.validatedAt)
     }
 
     @Test
@@ -101,7 +101,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
         Assertions.assertNotNull(result.code)
         Assertions.assertSame(preSendCount + 1, result.sendCount)
         Assertions.assertTrue(now.isEqual(result.requestedAt))
-        Assertions.assertNull(result.verifiedAt)
+        Assertions.assertNull(result.validatedAt)
     }
 
     @Test
@@ -139,7 +139,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
         Assertions.assertNotNull(result.code)
         Assertions.assertSame(1, result.sendCount)
         Assertions.assertTrue(now.isEqual(result.requestedAt))
-        Assertions.assertNull(result.verifiedAt)
+        Assertions.assertNull(result.validatedAt)
     }
     @Test
     @DisplayName("인증코드 일일 발송 제한량을 넘은 발급 기록이 있더라도 인증이 완료된 기록이면 발급 가능하다")
@@ -154,7 +154,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
             authCodeDomainService.issueLimitPerDay,
             now.minusHours(1)
         )
-        authCode.verifiedAt = LocalDateTime.now()
+        authCode.validatedAt = LocalDateTime.now()
 
         every { authCodeRepository.findByPhoneNumberAndAuthCodeType(phoneNumber, authCodeType) } returns authCode
         every {
@@ -164,7 +164,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
                         it.authCodeType === authCodeType &&
                         it.sendCount == 1 &&
                         it.requestedAt.isEqual(now) &&
-                        it.verifiedAt === null
+                        it.validatedAt === null
                 }
             )
         } returns authCode
@@ -178,7 +178,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
         Assertions.assertNotNull(result.code)
         Assertions.assertSame(1, result.sendCount)
         Assertions.assertTrue(now.isEqual(result.requestedAt))
-        Assertions.assertNull(result.verifiedAt)
+        Assertions.assertNull(result.validatedAt)
     }
 
     @Test
@@ -225,7 +225,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
                 match {
                     it.phoneNumber == phoneNumber &&
                         it.authCodeType === authCodeType &&
-                        it.verifiedAt!!.isEqual(now)
+                        it.validatedAt!!.isEqual(now)
                 }
             )
         } returns authCode
@@ -300,7 +300,7 @@ internal class AuthCodeDomainServiceTest() : BaseTestCase() {
             now.minusMinutes(authCodeDomainService.authCodeTTL.toLong())
         )
 
-        authCode.verifiedAt = LocalDateTime.now()
+        authCode.validatedAt = LocalDateTime.now()
 
         every { authCodeRepository.findByPhoneNumberAndAuthCodeType(phoneNumber, authCodeType) } returns authCode
 


### PR DESCRIPTION
도메인에서 사용하는 워딩과 달라 혼용, 오용을 방지 목적으로 워딩 일치화