### PR TITLE
bugfix - 패스워드 리셋 인증코드 발급시 잘못된 순서로 변수 전달하는 문제 해결

### DIFF
--- a/src/main/kotlin/io/github/acidfox/kopringbootauthapi/application/service/AuthCodeService.kt
+++ b/src/main/kotlin/io/github/acidfox/kopringbootauthapi/application/service/AuthCodeService.kt
@@ -25,7 +25,7 @@ class AuthCodeService(
 
     @Transactional
     fun issuePasswordResetAuthCode(phoneNumber: String, email: String) {
-        val isUserExists = userDomainService.existsByEmailAndPhoneNumber(phoneNumber, email)
+        val isUserExists = userDomainService.existsByEmailAndPhoneNumber(email, phoneNumber)
         authCodeDomainService.checkCanIssueAuthCode(isUserExists, AuthCodeType.RESET_PASSWORD)
         issue(phoneNumber, AuthCodeType.RESET_PASSWORD)
     }

--- a/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/user/service/UserDomainService.kt
+++ b/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/user/service/UserDomainService.kt
@@ -50,8 +50,8 @@ class UserDomainService(
     }
 
     fun existsByPhoneNumber(phoneNumber: String) = userRepository.existsByPhoneNumber(phoneNumber)
-    fun existsByEmailAndPhoneNumber(phoneNumber: String, email: String) =
-        userRepository.existsByEmailAndPhoneNumber(phoneNumber, email)
+    fun existsByEmailAndPhoneNumber(email: String, phoneNumber: String) =
+        userRepository.existsByEmailAndPhoneNumber(email, phoneNumber)
     fun findByEmail(email: String) = userRepository.findByEmail(email)
     fun findByEmailAndPhoneNumber(email: String, phoneNumber: String) =
         userRepository.findByEmailAndPhoneNumber(email, phoneNumber)

--- a/src/test/kotlin/io/github/acidfox/kopringbootauthapi/application/service/AuthCodeServiceTest.kt
+++ b/src/test/kotlin/io/github/acidfox/kopringbootauthapi/application/service/AuthCodeServiceTest.kt
@@ -69,7 +69,7 @@ internal class AuthCodeServiceTest() : BaseTestCase() {
         )
 
         every { spyAuthCodeService.issuePasswordResetAuthCode(phoneNumber, email) } answers { callOriginal() }
-        every { userDomainService.existsByEmailAndPhoneNumber(phoneNumber, email) } returns true
+        every { userDomainService.existsByEmailAndPhoneNumber(email, phoneNumber) } returns true
         every {
             authCodeDomainService.checkCanIssueAuthCode(true, AuthCodeType.RESET_PASSWORD)
         } returns true
@@ -78,7 +78,7 @@ internal class AuthCodeServiceTest() : BaseTestCase() {
         spyAuthCodeService.issuePasswordResetAuthCode(phoneNumber, email)
 
         // Then
-        verify(exactly = 1) { userDomainService.existsByEmailAndPhoneNumber(phoneNumber, email) }
+        verify(exactly = 1) { userDomainService.existsByEmailAndPhoneNumber(email, phoneNumber) }
         verify(exactly = 1) {
             authCodeDomainService.checkCanIssueAuthCode(true, AuthCodeType.RESET_PASSWORD)
         }


### PR DESCRIPTION
메서드명과 인자 순서는 동일하게 하도록하자...