### PR TITLE
refact - CanNotIssuedAuthCodeException Exception Response Code 변경

### DIFF
--- a/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/exception/CanNotIssuedAuthCodeException.kt
+++ b/src/main/kotlin/io/github/acidfox/kopringbootauthapi/domain/authcode/exception/CanNotIssuedAuthCodeException.kt
@@ -4,5 +4,5 @@ import io.github.acidfox.kopringbootauthapi.infrastructure.error.CustomException
 import org.springframework.http.HttpStatus
 
 class CanNotIssuedAuthCodeException(message: String) : CustomException(HttpStatus.FORBIDDEN, message) {
-    override val code: Int = 999
+    override val code: Int = 99
 }


### PR DESCRIPTION
일관성을 위해 수정합니다.